### PR TITLE
Repair HRMP cancel operation

### DIFF
--- a/scripts/helpers/hrmp-helper.ts
+++ b/scripts/helpers/hrmp-helper.ts
@@ -10,6 +10,7 @@ export async function hrmpHelper(
   targetParaId,
   maxCapacity = 1000,
   maxMessageSize = 102400,
+  openRequests = 255,
   feeCurrency = null,
   fee = null,
   forceXcmSend = null
@@ -136,10 +137,13 @@ export async function hrmpHelper(
     } else if (hrmpAction == "open") {
       relayCall = relayApi.tx.hrmp.hrmpInitOpenChannel(targetParaId, maxCapacity, maxMessageSize);
     } else if (hrmpAction == "cancel") {
-      relayCall = relayApi.tx.hrmp.hrmpCancelOpenRequest({
-        sender: selfParaId,
-        recipient: targetParaId,
-      });
+      relayCall = relayApi.tx.hrmp.hrmpCancelOpenRequest(
+        {
+          sender: selfParaId,
+          recipient: targetParaId,
+        },
+        openRequests
+      );
     } else {
       relayCall = relayApi.tx.hrmp.hrmpCloseChannel({
         sender: selfParaId,

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -27,6 +27,7 @@ const args = yargs.options({
   "target-para-id": { type: "number", demandOption: true, alias: "p" },
   "max-capacity": { type: "number", demandOption: false, alias: "mc" },
   "max-message-size": { type: "number", demandOption: false, alias: "mms" },
+  "open-requests": { type: "number", demandOption: false, alias: "os" },
   "account-priv-key": { type: "string", demandOption: false, alias: "account" },
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
@@ -61,6 +62,7 @@ async function main() {
     args["target-para-id"],
     args["max-capacity"],
     args["max-message-size"],
+    args["open-requests"],
     args["fee-currency"],
     args["fee-amount"],
     args["force-xcm-send"]


### PR DESCRIPTION
When executing the hrmp channel manipulator operation "cancel", the following error occurs:
> Error: Extrinsic hrmp.hrmpCancelOpenRequest expects 2 arguments, got 1.
    at extrinsicFn (/home/sea212/Documents/github/xcm-tools/node_modules/@polkadot/types/cjs/metadata/decorate/extrinsics/createUnchecked.js:14:19)
    at Object.decorated [as hrmpCancelOpenRequest] (/home/sea212/Documents/github/xcm-tools/node_modules/@polkadot/api/cjs/base/Decorate.js:467:50)
    at Object.hrmpHelper (/home/sea212/Documents/github/xcm-tools/scripts/helpers/hrmp-helper.ts:139:36)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async main (/home/sea212/Documents/github/xcm-tools/scripts/hrmp-channel-manipulator.ts:57:19)

The function [`hrmp_cancel_open_request`](https://github.com/paritytech/polkadot/blob/6f991987c0b4cbbd7d4badc9ef08d83da5fefbfd/runtime/parachains/src/hrmp.rs#L569-L593) has a second parameter [`open_requests`](https://github.com/paritytech/polkadot/blob/6f991987c0b4cbbd7d4badc9ef08d83da5fefbfd/runtime/parachains/src/hrmp.rs#L582) that is not handled in the script.

This PR adds the second parameter and an optional argument to script called `open-requests` to set that value. As a default, the value 255 is used to [ensure a successful execution](https://github.com/paritytech/polkadot/blob/6f991987c0b4cbbd7d4badc9ef08d83da5fefbfd/runtime/parachains/src/hrmp.rs#L585-L589) of the channel request cancel operation (if configured properly otherwise) in most cases while [not over-estimating the required weight](https://github.com/paritytech/polkadot/blob/6f991987c0b4cbbd7d4badc9ef08d83da5fefbfd/runtime/parachains/src/hrmp.rs#L578) too much.