### PR TITLE
Expand Decode XCM Msgs to Generic XCM Bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,38 +269,42 @@ The `track` field must be a JSON formatted representation of the `referenda.subm
 
 A coumple of scripts that allow to decode XCM messages in the relay chain (`decode-xcm-relay`) and in any parachain (`decode-xcm-para`). This first iteration can be easily expanded to support and expand on more XCM instructions.
 
-The script accepts these inputs fields:
-- `--parachain-ws-provider` or `--w`, which specifies the websocket provider of the parachain in which the address should be calculated
-- `--multilocation` or `-m`, the multilocation for which we want to calculate the derivated address
-
 ### Decode XCM Relay
 
 Script to specifically decode XCM messages sent to the relay chain via UMP.
 
 The script accepts these input fields:
-- `--relay-ws-provider` or `--w`, which specifies the websocket provider of the relay chain in which the XCM will be decoded
+- `--relay-ws-provider` or `--w`, which specifies the websocket provider of the relay chain in which the XCM will be decoded (required)
 - `--block-number` or `-b`, which specifies the block number where the XCM message to be decoded is contained
 - `--para-id` or `-p`, which specifies the parachain ID from which the XCM message was sent from
+- `--message` or `-m`, if you want to just decode a XCM message that you have as bytes (for example, via Chopsticks) you can just provide it as bytes
 
 For example:
 
 `yarn xcm-decode-relay --w wss://kusama-rpc.polkadot.io --b 12034878 --p 2023`
+
+`yarn xcm-decode-relay --w wss://rpc.polkadot.io --m "0x03100004000000000700e40b540213000000000700e40b5402010700863ba101020008001608140d010204000100511f060002286bee02000400183c0135080000"`
+
 
 ### Decode XCM Parachain
 
 Script to specifically decode XCM messages sent to parachains either via DMP or HRMP/XCMP
 
 The script accepts these input fields:
-- `--para-ws-provider` or `--w`, which specifies the websocket provider of the parachain in which the XCM will be decoded
+- `--para-ws-provider` or `--w`, which specifies the websocket provider of the parachain in which the XCM will be decoded (required)
+- `--channel`, which specifies the type of channel (or transport method) the XCM is being delivered through. Valid options are `dmp` and `hrmp`/`xcmp` (although anything different than `dmp` defaults to `hrmp` or `xcmp`) (required)
 - `--block-number` or `-b`, which specifies the block number where the XCM message to be decoded is contained
-- `--channel`, which specifies the type of channel (or transport method) the XCM is being delivered through. Valid options are `dmp` and `hrmp`/`xcmp` (although anything different than `dmp` defaults to `hrmp` or `xcmp`)
 - `--para-id` or `-p`, (optional if channel is hrmp/xcmp) which specifies the parachain ID from which the XCM message was sent from
+- `--message` or `-m`, if you want to just decode a XCM message that you have as bytes (for example, via Chopsticks) you can just provide it as bytes
+
 
 For example:
 
 `yarn xcm-decode-para --w wss://wss.api.moonriver.moonbeam.network --b 2391172 --channel dmp`
 
 `yarn xcm-decode-para --w wss://wss.api.moonbeam.network --b 1649282 --channel hrmp --p 2000`
+
+`yarn xcm-decode-para --w wss://wss.api.moonbeam.network --channel hrmp --m "0x0003100004000001040a00130000f444829163450a13000001040a00130000f44482916345000d01020400010300f24ff3a9cf04c71dbc94d0b566f7a27b94566cac"`
 
 ## Calculate Sovereign Account
 

--- a/scripts/decode-xcm-para.ts
+++ b/scripts/decode-xcm-para.ts
@@ -2,12 +2,14 @@
 import { ApiPromise, WsProvider } from "@polkadot/api";
 import yargs from "yargs";
 import { decodeXCMGeneric } from "./helpers/decode-xcm-generic";
+import { hexToU8a } from "@polkadot/util";
 
 const args = yargs.options({
   "para-ws-provider": { type: "string", demandOption: true, alias: "w" },
-  "block-number": { type: "number", demandOption: true, alias: "b" },
+  "block-number": { type: "number", demandOption: false, alias: "b" },
   channel: { choices: ["dmp", "hrmp"], demandOption: true, alias: "channel" },
   "para-id": { type: "number", demandOption: false, alias: "p" },
+  message: { type: "string", demandOption: false, alias: "m" },
 }).argv;
 
 // Construct
@@ -17,40 +19,51 @@ async function main() {
   // Provider
   const paraApi = await ApiPromise.create({ provider: paraProvider });
 
-  // Get block hash
-  const blockHash = (await paraApi.rpc.chain.getBlockHash(args["block-number"])) as Uint8Array;
-  // Get block by hash
-  const signedBlock = (await paraApi.rpc.chain.getBlock(blockHash)) as any;
+  if (args["block-number"]) {
+    // Get block hash
+    const blockHash = (await paraApi.rpc.chain.getBlockHash(args["block-number"])) as Uint8Array;
+    // Get block by hash
+    const signedBlock = (await paraApi.rpc.chain.getBlock(blockHash)) as any;
 
-  // the hash for each extrinsic in the block
-  signedBlock.block.extrinsics.forEach((ex, index) => {
-    // Parachain Inherent set validation data.
-    // Probably needs to be mapped to pallet index too
-    if (ex.method._meta["name"] == "set_validation_data") {
-      if (args["channel"] == "dmp") {
-        // Check downward messages (from relay chain to parachain)
-        // Go through each message
-        ex.method.args[0].downwardMessages.forEach((message) => {
-          // We recover all instructions
-          decodeXCMGeneric(paraApi, message, 1); //Type 1 is DMP
-        });
-      } else {
-        // Check hrmp messages (from parachain to parachain)
-        // Types
-        const para = paraApi.createType("ParaId", args["para-id"]) as any;
-        ex.method.args[0].horizontalMessages.forEach((messages, paraId) => {
-          // Filter by the paraId that we want
-          if (paraId.eq(para)) {
-            // Go through each message
-            messages.forEach((message) => {
-              // We recover all instructions
-              decodeXCMGeneric(paraApi, message, 2); //Type 2 is HRMP
-            });
-          }
-        });
+    // the hash for each extrinsic in the block
+    signedBlock.block.extrinsics.forEach((ex, index) => {
+      // Parachain Inherent set validation data.
+      // Probably needs to be mapped to pallet index too
+      if (ex.method._meta["name"] == "set_validation_data") {
+        if (args["channel"] == "dmp") {
+          // Check downward messages (from relay chain to parachain)
+          // Go through each message
+          ex.method.args[0].downwardMessages.forEach((message) => {
+            // We recover all instructions
+            decodeXCMGeneric(paraApi, message.msg); // Message is DMP
+          });
+        } else {
+          // Check hrmp messages (from parachain to parachain)
+          // Types
+          const para = paraApi.createType("ParaId", args["para-id"]) as any;
+          ex.method.args[0].horizontalMessages.forEach((messages, paraId) => {
+            // Filter by the paraId that we want
+            if (paraId.eq(para)) {
+              // Go through each message
+              messages.forEach((message) => {
+                // We recover all instructions
+                // XCM going from a Parachain to another Parachain (HRMP/XCMP)
+                // First byte is a format version that creates problem when decoding it as XcmVersionedXcm
+                // We remove it
+                decodeXCMGeneric(paraApi, message.data.slice(1));
+              });
+            }
+          });
+        }
       }
+    });
+  } else if (args["message"]) {
+    if (args["channel"] == "dmp") {
+      decodeXCMGeneric(paraApi, hexToU8a(args["message"]).slice(1)); // Message is DMP
+    } else {
+      decodeXCMGeneric(paraApi, hexToU8a(args["message"]).slice(1)); //Message is HRMP, Slice 1st Byte
     }
-  });
+  }
 }
 
 main()

--- a/scripts/decode-xcm-relay.ts
+++ b/scripts/decode-xcm-relay.ts
@@ -2,11 +2,13 @@
 import { ApiPromise, WsProvider } from "@polkadot/api";
 import yargs from "yargs";
 import { decodeXCMGeneric } from "./helpers/decode-xcm-generic";
+import { hexToU8a } from "@polkadot/util";
 
 const args = yargs.options({
   "relay-ws-provider": { type: "string", demandOption: true, alias: "w" },
-  "block-number": { type: "number", demandOption: true, alias: "b" },
-  "para-id": { type: "number", demandOption: true, alias: "p" },
+  "block-number": { type: "number", demandOption: false, alias: "b" },
+  "para-id": { type: "number", demandOption: false, alias: "p" },
+  message: { type: "string", demandOption: false, alias: "m" },
 }).argv;
 
 // Construct
@@ -16,37 +18,43 @@ async function main() {
   // Provider
   const relayApi = await ApiPromise.create({ provider: relayProvider });
 
-  // Types
-  const para = relayApi.createType("ParaId", args["para-id"]) as any;
+  if (args["para-id"] && args["block-number"]) {
+    // Types
+    const para = relayApi.createType("ParaId", args["para-id"]) as any;
 
-  // Get block hash
-  const blockHash = (await relayApi.rpc.chain.getBlockHash(args["block-number"])) as Uint8Array;
-  // Get block by hash
-  const signedBlock = (await relayApi.rpc.chain.getBlock(blockHash)) as any;
+    // Get block hash
+    const blockHash = (await relayApi.rpc.chain.getBlockHash(args["block-number"])) as Uint8Array;
+    // Get block by hash
+    const signedBlock = (await relayApi.rpc.chain.getBlock(blockHash)) as any;
 
-  // The hash for each extrinsic in the block
-  signedBlock.block.extrinsics.forEach((extrinsic) => {
-    // Parachain Inherent enter.
-    // Probably needs to be mapped to pallet index too
-    if (extrinsic.method._meta["name"] == "enter") {
-      // There might be a backed candidate for different parachains, filter by para ID
-      extrinsic.method.args[0].backedCandidates.forEach((candidate) => {
-        if (candidate.candidate.descriptor.paraId.eq(para) == true) {
-          // Check upward messages (from parachain to relay chain)
-          candidate.candidate.commitments["upwardMessages"].forEach((message) => {
-            // Print the Blake2 Hash of the message
-            console.log(
-              `The ump.ExecutedUpward event with the hash is in the following block: ${
-                args["block-number"] + 1
-              }`
-            );
-            // We recover all instructions
-            decodeXCMGeneric(relayApi, message, 0); //Type 0 is UMP
-          });
-        }
-      });
-    }
-  });
+    // The hash for each extrinsic in the block
+    signedBlock.block.extrinsics.forEach((extrinsic) => {
+      // Parachain Inherent enter.
+      // Probably needs to be mapped to pallet index too
+      if (extrinsic.method._meta["name"] == "enter") {
+        // There might be a backed candidate for different parachains, filter by para ID
+        extrinsic.method.args[0].backedCandidates.forEach((candidate) => {
+          if (candidate.candidate.descriptor.paraId.eq(para) == true) {
+            // Check upward messages (from parachain to relay chain)
+            candidate.candidate.commitments["upwardMessages"].forEach((message) => {
+              // Print the Blake2 Hash of the message
+              console.log(
+                `The ump.ExecutedUpward event with the hash is in the following block: ${
+                  args["block-number"] + 1
+                }`
+              );
+              // We recover all instructions
+              decodeXCMGeneric(relayApi, message);
+            });
+          }
+        });
+      }
+    });
+  } else if (args["message"]) {
+    decodeXCMGeneric(relayApi, hexToU8a(args["message"]));
+  } else {
+    throw new Error("Check required inputs!");
+  }
 }
 
 main()

--- a/scripts/helpers/decode-xcm-generic.ts
+++ b/scripts/helpers/decode-xcm-generic.ts
@@ -3,28 +3,10 @@ import { blake2AsU8a } from "@polkadot/util-crypto";
 import { u8aToHex } from "@polkadot/util";
 import type { XcmVersionedXcm } from "@polkadot/types/lookup";
 
-export function decodeXCMGeneric(provider: any, message: any, type: number) {
+export function decodeXCMGeneric(provider: any, message: any) {
+  // Retrieve XCM Fragments
   let fragments;
-  switch (type) {
-    case 0:
-      // XCM going to the Relay Chain (UMP)
-      fragments = decodeMessageIntoFragmentVec(provider, message);
-      break;
-    case 1:
-      // XCM going from the Relay Chain to a Parachain (DMP)
-      fragments = decodeMessageIntoFragmentVec(provider, message.msg);
-      break;
-    case 2:
-      // XCM going from a Parachain to another Parachain (HRMP/XCMP)
-      // First byte is a format version that creates problem when decoding it as XcmVersionedXcm
-      // We remove it
-
-      fragments = decodeMessageIntoFragmentVec(provider, message.data.slice(1));
-      break;
-    default:
-      console.error("Not supporting this particular scenario!");
-      break;
-  }
+  fragments = decodeMessageIntoFragmentVec(provider, message);
 
   for (let i = 0; i < fragments.length; i++) {
     let instructions = fragments[i];


### PR DESCRIPTION
This PR adds a pretty cool functionality in which now you can provide the hex bytes of an XCM message and it will decode it. Not needing to provide the block or parachain ID.

It is helpful to debug XCM things with Chopsticks, as running Chopsticks forks with verbose log like `export VERBOSE_LOG="true"` as it will prompt all the bytes of the XCM message (without truncating)