### PR TITLE
Account derivation scheme generalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The script accepts these inputs fields:
 - `--sufficient` or `--suf`, boolean indicating whether the asset should exist without a provider reference
 - `--revert-code` or `--revert`, boolean specifying whether we want register the revert code in the evm
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
+- `--account-type` or `-accType`, which specifies the account derivation scheme to use. Options are `ethereum` (default), `sr25519` or `ed25519`
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash    
 - `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
 - `--collective-threshold` or `-c`, Optional, number specifying the number of council votes that need to aprove the proposal. If not provided defautls to 1.
@@ -69,6 +70,7 @@ The script accepts these inputs fields:
 - `--xcm-transactor-address` or `--xcmt`, optional, if provided, it will set the revert code at that address.
 - `--relay-encoder-address` or `--re`, optional, if provided, it will set the revert code at that address.
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
+- `--account-type` or `-accType`, which specifies the account derivation scheme to use. Options are `ethereum` (default), `sr25519` or `ed25519`
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
 - `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
@@ -104,6 +106,7 @@ The script accepts these inputs fields:
 - `--max-capacity` or `--mc`, Optional, only for "open". The max capacity in messages that the channel supports
 - `--max-message-size` or `-mms`, Optional, only for "open". The max message size that the channel supports
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
+- `--account-type` or `-accType`, which specifies the account derivation scheme to use. Options are `ethereum` (default), `sr25519` or `ed25519`
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
 - `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
@@ -143,6 +146,7 @@ The script accepts these inputs fields:
 - `--fee-per-weight` or `--fw`, the amount of fee the destination will charge per weight
 - `--extra-weight` or `--ew`, the amount of extra weight that sending the transact XCM message involves
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
+- `--account-type` or `-accType`, which specifies the account derivation scheme to use. Options are `ethereum` (default), `sr25519` or `ed25519`
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
 - `--send-proposal` or `-s`, optional, but if providede needs to be "democracy" or "council-external" specifying whether we want to send the proposal through regular democracy or as an external proposal that will be voted by the council
@@ -176,6 +180,7 @@ The script accepts these inputs fields:
 - `--owner` or `--o`, the parachain account that will own the derivative index
 - `--index` or `--i`, the index that the owner will own
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
+- `--account-type` or `-accType`, which specifies the account derivation scheme to use. Options are `ethereum` (default), `sr25519` or `ed25519`
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
 - `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
@@ -239,6 +244,7 @@ The script accepts these inputs fields:
 - `--ws-provider` or `-w`, which specifies the websocket provider to which we will be issuing our requests
 - `--generic-call` or `--call`, the call (as hex string) that should be proposed through democracy. Can be passed many times, if we want to batch several together
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
+- `--account-type` or `-accType`, which specifies the account derivation scheme to use. Options are `ethereum` (default), `sr25519` or `ed25519`
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
 - `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "calculate-external-asset-info": "ts-node 'scripts/calculate-external-asset-info.ts'",
     "calculate-local-asset-info": "ts-node 'scripts/calculate-local-asset-info.ts'",
     "calculate-multilocation-derivative-account": "ts-node 'scripts/calculate-multilocation-derivative-account.ts'",
+    "calculate-remote-origin": "ts-node 'scripts/calculate-multilocation-derivative-account.ts'",
     "calculate-units-per-second": "ts-node 'scripts/calculate-units-per-second.ts'"
   },
   "dependencies": {

--- a/scripts/calculate-external-asset-info.ts
+++ b/scripts/calculate-external-asset-info.ts
@@ -27,6 +27,7 @@ const main = async () => {
   // Wait for Provider
   const api = await ApiPromise.create({
     provider: wsProvider,
+    noInitWarn: true,
   });
   await api.isReady;
 

--- a/scripts/calculate-local-asset-info.ts
+++ b/scripts/calculate-local-asset-info.ts
@@ -40,6 +40,7 @@ const main = async () => {
   // Wait for Provider
   const api = await ApiPromise.create({
     provider: wsProvider,
+    noInitWarn: true,
   });
   await api.isReady;
 

--- a/scripts/generic-call-proposer.ts
+++ b/scripts/generic-call-proposer.ts
@@ -14,6 +14,7 @@ const args = yargs.options({
   "ws-provider": { type: "string", demandOption: true, alias: "w" },
   "generic-call": { type: "string", demandOption: true, alias: "call" },
   "account-priv-key": { type: "string", demandOption: false, alias: "account" },
+  "account-type": { type: "string", demandOption: false, alias: "accType", default: "ethereum" },
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
   "send-proposal-as": {
@@ -73,7 +74,7 @@ async function main() {
   let account;
   let nonce;
   if (args["account-priv-key"]) {
-    [account, nonce] = await accountWrapper(api, args["account-priv-key"]);
+    [account, nonce] = await accountWrapper(api, args["account-priv-key"], args["account-type"]);
   }
 
   // Sudo Wrapper

--- a/scripts/helpers/function-helpers.ts
+++ b/scripts/helpers/function-helpers.ts
@@ -6,12 +6,16 @@ export function schedulerWrapper(api, atBlock, tx) {
   return api.tx.scheduler.schedule(atBlock, null, 0, tx);
 }
 
-export async function accountWrapper(api, privateKey) {
+export async function accountWrapper(api, privateKey, accountType) {
+  // Check account input type
+  if (!["ethereum", "sr25519", "ed25519"].includes(accountType)) {
+    throw new Error("Account types supported are ethereum, sr25519 and ed25519");
+  }
   // Keyring
-  const keyring = new Keyring({ type: "ethereum" });
+  const keyring = new Keyring({ type: accountType });
 
   // Create account and get nonce
-  let account = await keyring.addFromUri(privateKey, null, "ethereum");
+  let account = await keyring.addFromUri(privateKey, null, accountType);
   const { nonce: rawNonce } = (await api.query.system.account(account.address)) as any;
   let nonce = BigInt(rawNonce.toString());
 

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -29,6 +29,7 @@ const args = yargs.options({
   "max-message-size": { type: "number", demandOption: false, alias: "mms" },
   "open-requests": { type: "number", demandOption: false, alias: "os" },
   "account-priv-key": { type: "string", demandOption: false, alias: "account" },
+  "account-type": { type: "string", demandOption: false, alias: "accType", default: "ethereum" },
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
   "send-proposal-as": {
@@ -80,7 +81,7 @@ async function main() {
   let account;
   let nonce;
   if (args["account-priv-key"]) {
-    [account, nonce] = await accountWrapper(api, args["account-priv-key"]);
+    [account, nonce] = await accountWrapper(api, args["account-priv-key"], args["account-type"]);
   }
 
   // Sudo Wrapper

--- a/scripts/para-registrar-swapper.ts
+++ b/scripts/para-registrar-swapper.ts
@@ -1,128 +1,138 @@
 // Import
-import { ApiPromise, WsProvider } from '@polkadot/api';
-import { u8aToHex, hexToU8a } from '@polkadot/util';
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { u8aToHex, hexToU8a } from "@polkadot/util";
 import { BN } from "@polkadot/util";
 
-import { blake2AsHex, xxhashAsU8a, blake2AsU8a } from '@polkadot/util-crypto';
-import yargs from 'yargs';
+import { blake2AsHex, xxhashAsU8a, blake2AsU8a } from "@polkadot/util-crypto";
+import yargs from "yargs";
 import { Keyring } from "@polkadot/api";
-import { ParaId } from '@polkadot/types/interfaces';
-import { democracyWrapper, preimageWrapper, accountWrapper, schedulerWrapper } from './helpers/function-helpers';
+import { ParaId } from "@polkadot/types/interfaces";
+import {
+  democracyWrapper,
+  preimageWrapper,
+  accountWrapper,
+  schedulerWrapper,
+} from "./helpers/function-helpers";
 
 const args = yargs.options({
-    'parachain-ws-provider': { type: 'string', demandOption: true, alias: 'wp' },
-    'relay-ws-provider': { type: 'string', demandOption: true, alias: 'wr' },
-    'old-para-id': { type: 'number', demandOption: true, alias: 'p' },
-    'new-para-id': { type: 'number', demandOption: true, alias: 'np' },
-    'account-priv-key': { type: 'string', demandOption: false, alias: 'account' },
-    'send-preimage-hash': { type: 'boolean', demandOption: false, alias: 'h' },
-    "send-proposal-as": {
-        choices: ["democracy", "v1", "council-external", "v2"],
-        demandOption: false,
-        alias: "s",
-    }, 'collective-threshold': { type: 'number', demandOption: false, alias: 'c' },
-    "delay": { type: "string", demandOption: false },
-    "track": { type: "string", demandOption: false },
-    'at-block': { type: 'number', demandOption: false },
+  "parachain-ws-provider": { type: "string", demandOption: true, alias: "wp" },
+  "relay-ws-provider": { type: "string", demandOption: true, alias: "wr" },
+  "old-para-id": { type: "number", demandOption: true, alias: "p" },
+  "new-para-id": { type: "number", demandOption: true, alias: "np" },
+  "account-priv-key": { type: "string", demandOption: false, alias: "account" },
+  "account-type": { type: "string", demandOption: false, alias: "accType", default: "ethereum" },
+  "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
+  "send-proposal-as": {
+    choices: ["democracy", "v1", "council-external", "v2"],
+    demandOption: false,
+    alias: "s",
+  },
+  "collective-threshold": { type: "number", demandOption: false, alias: "c" },
+  delay: { type: "string", demandOption: false },
+  track: { type: "string", demandOption: false },
+  "at-block": { type: "number", demandOption: false },
 }).argv;
 
 // Construct
-const wsProvider = new WsProvider(args['parachain-ws-provider']);
-const relayProvider = new WsProvider(args['relay-ws-provider']);
+const wsProvider = new WsProvider(args["parachain-ws-provider"]);
+const relayProvider = new WsProvider(args["relay-ws-provider"]);
 
 async function main() {
-    const api = await ApiPromise.create({ provider: wsProvider });
-    const relayApi = await ApiPromise.create({ provider: relayProvider });
+  const api = await ApiPromise.create({ provider: wsProvider });
+  const relayApi = await ApiPromise.create({ provider: relayProvider });
 
-    const selfParaId: ParaId = await api.query.parachainInfo.parachainId() as any;
+  const selfParaId: ParaId = (await api.query.parachainInfo.parachainId()) as any;
 
-    let relayCall;
-    relayCall = relayApi.tx.registrar.swap(
-        args["old-para-id"],
-        args["new-para-id"]
-    )
+  let relayCall;
+  relayCall = relayApi.tx.registrar.swap(args["old-para-id"], args["new-para-id"]);
 
-    let relayCall2 = relayCall?.method.toHex() || "";
-    // Sovereign account is b"para" + encode(parahain ID) + trailling zeros
-    let para_address = u8aToHex((new Uint8Array([...new TextEncoder().encode("para"), ...selfParaId.toU8a()]))).padEnd(66, "0");
+  let relayCall2 = relayCall?.method.toHex() || "";
+  // Sovereign account is b"para" + encode(parahain ID) + trailling zeros
+  let para_address = u8aToHex(
+    new Uint8Array([...new TextEncoder().encode("para"), ...selfParaId.toU8a()])
+  ).padEnd(66, "0");
 
-    const xcmSendTx = api.tx.polkadotXcm.send(
-        { V1: { parents: new BN(1), interior: "Here" } },
+  const xcmSendTx = api.tx.polkadotXcm.send(
+    { V1: { parents: new BN(1), interior: "Here" } },
+    {
+      V2: [
         {
-            V2: [
-                {
-                    WithdrawAsset: [
-                        {
-                            id: { Concrete: { parents: new BN(0), interior: "Here" } },
-                            fun: { Fungible: new BN(1000000000000) }
-                        }
-                    ]
-                },
-                {
-                    BuyExecution: {
-                        fees:
-                        {
-                            id: { Concrete: { parents: new BN(0), interior: "Here" } },
-                            fun: { Fungible: new BN(1000000000000) }
-                        },
-                        weightLimit: { Limited: new BN(6000000000) }
-                    }
-                },
-                {
-                    Transact: {
-                        originType: "Native",
-                        requireWeightAtMost: new BN(2000000000),
-                        call: {
-                            encoded: relayCall2
-                        }
-                    }
-                },
-                {
-                    DepositAsset: {
-                        assets: { Wild: "All" },
-                        max_assets: 1,
-                        beneficiary: { parents: new BN(0), interior: { X1: { AccountId32: { network: "Any", id: para_address } } } }
-                    }
-                },
-            ]
-        });
-
-    // Scheduler
-    const finalTx = args['at-block'] ? schedulerWrapper(api, args["at-block"], xcmSendTx) : xcmSendTx;
-
-    // Prepare proposal encoded data
-    let encodedProposal = finalTx?.method.toHex() || "";
-    console.log("Encoded Call Data for Tx is %s", encodedProposal);
-
-    // Get account
-    let account, nonce;
-    if (args["account-priv-key"]) {
-        [account, nonce] = await accountWrapper(api, args["account-priv-key"]);
+          WithdrawAsset: [
+            {
+              id: { Concrete: { parents: new BN(0), interior: "Here" } },
+              fun: { Fungible: new BN(1000000000000) },
+            },
+          ],
+        },
+        {
+          BuyExecution: {
+            fees: {
+              id: { Concrete: { parents: new BN(0), interior: "Here" } },
+              fun: { Fungible: new BN(1000000000000) },
+            },
+            weightLimit: { Limited: new BN(6000000000) },
+          },
+        },
+        {
+          Transact: {
+            originType: "Native",
+            requireWeightAtMost: new BN(2000000000),
+            call: {
+              encoded: relayCall2,
+            },
+          },
+        },
+        {
+          DepositAsset: {
+            assets: { Wild: "All" },
+            max_assets: 1,
+            beneficiary: {
+              parents: new BN(0),
+              interior: { X1: { AccountId32: { network: "Any", id: para_address } } },
+            },
+          },
+        },
+      ],
     }
+  );
 
-    // Create Preimage
-    let preimage;
-    if (args["send-preimage-hash"]) {
-        [preimage, nonce] = await preimageWrapper(api, encodedProposal, account, nonce);
-    }
+  // Scheduler
+  const finalTx = args["at-block"] ? schedulerWrapper(api, args["at-block"], xcmSendTx) : xcmSendTx;
 
-    // Send Democracy Proposal
-    if (args["send-proposal-as"]) {
-        const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
-        const collectiveThreshold = args['collective-threshold'] ?? 1;
+  // Prepare proposal encoded data
+  let encodedProposal = finalTx?.method.toHex() || "";
+  console.log("Encoded Call Data for Tx is %s", encodedProposal);
 
-        await democracyWrapper(
-            api,
-            args["send-proposal-as"],
-            preimage,
-            account,
-            nonce,
-            collectiveThreshold,
-            args["track"],
-            args["delay"]
-        );
-    }
+  // Get account
+  let account, nonce;
+  if (args["account-priv-key"]) {
+    [account, nonce] = await accountWrapper(api, args["account-priv-key"], args["account-type"]);
+  }
+
+  // Create Preimage
+  let preimage;
+  if (args["send-preimage-hash"]) {
+    [preimage, nonce] = await preimageWrapper(api, encodedProposal, account, nonce);
+  }
+
+  // Send Democracy Proposal
+  if (args["send-proposal-as"]) {
+    const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
+    const collectiveThreshold = args["collective-threshold"] ?? 1;
+
+    await democracyWrapper(
+      api,
+      args["send-proposal-as"],
+      preimage,
+      account,
+      nonce,
+      collectiveThreshold,
+      args["track"],
+      args["delay"]
+    );
+  }
 }
 
-
-main().catch(console.error).finally(() => process.exit());
+main()
+  .catch(console.error)
+  .finally(() => process.exit());

--- a/scripts/xcm-asset-registrator.ts
+++ b/scripts/xcm-asset-registrator.ts
@@ -23,6 +23,7 @@ const args = yargs.options({
   "existential-deposit": { type: "number", demandOption: false, alias: "ed" },
   sufficient: { type: "boolean", demandOption: false, alias: "suf" },
   "account-priv-key": { type: "string", demandOption: false, alias: "account" },
+  "account-type": { type: "string", demandOption: false, alias: "accType", default: "ethereum" },
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "revert-code": { type: "boolean", demandOption: false, alias: "revert" },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
@@ -124,7 +125,7 @@ async function main() {
   let account;
   let nonce;
   if (args["account-priv-key"]) {
-    [account, nonce] = await accountWrapper(api, args["account-priv-key"]);
+    [account, nonce] = await accountWrapper(api, args["account-priv-key"], args["account-type"]);
   }
 
   // Sudo Wrapper

--- a/scripts/xcm-derivative-index-registrar.ts
+++ b/scripts/xcm-derivative-index-registrar.ts
@@ -14,6 +14,7 @@ const args = yargs.options({
   index: { type: "number", demandOption: true, alias: "i" },
   owner: { type: "string", demandOption: true, alias: "o" },
   "account-priv-key": { type: "string", demandOption: false, alias: "account" },
+  "account-type": { type: "string", demandOption: false, alias: "accType", default: "ethereum" },
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
   "send-proposal-as": {
@@ -23,8 +24,8 @@ const args = yargs.options({
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
-  "delay": { type: "string", demandOption: false },
-  "track": { type: "string", demandOption: false }
+  delay: { type: "string", demandOption: false },
+  track: { type: "string", demandOption: false },
 }).argv;
 
 // Construct
@@ -44,7 +45,7 @@ async function main() {
   let account;
   let nonce;
   if (args["account-priv-key"]) {
-    [account, nonce] = await accountWrapper(api, args["account-priv-key"]);
+    [account, nonce] = await accountWrapper(api, args["account-priv-key"], args["account-type"]);
   }
 
   // Sudo Wrapper

--- a/scripts/xcm-initializer.ts
+++ b/scripts/xcm-initializer.ts
@@ -18,6 +18,7 @@ const args = yargs.options({
   "relay-encoder-address": { type: "string", demandOption: false, alias: "re" },
   "default-xcm-version": { type: "number", demandOption: false, alias: "d" },
   "account-priv-key": { type: "string", demandOption: false, alias: "account" },
+  "account-type": { type: "string", demandOption: false, alias: "accType", default: "ethereum" },
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
   "send-proposal-as": {
@@ -26,8 +27,8 @@ const args = yargs.options({
     alias: "s",
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
-  "delay": { type: "string", demandOption: false },
-  "track": { type: "string", demandOption: false }
+  delay: { type: "string", demandOption: false },
+  track: { type: "string", demandOption: false },
 }).argv;
 
 // Construct
@@ -137,7 +138,7 @@ async function main() {
   let account;
   let nonce;
   if (args["account-priv-key"]) {
-    [account, nonce] = await accountWrapper(api, args["account-priv-key"]);
+    [account, nonce] = await accountWrapper(api, args["account-priv-key"], args["account-type"]);
   }
 
   // Sudo Wrapper

--- a/scripts/xcm-transactor-info-setter.ts
+++ b/scripts/xcm-transactor-info-setter.ts
@@ -20,6 +20,7 @@ const args = yargs.options({
   index: { type: "number", demandOption: false, alias: "i" },
   owner: { type: "string", demandOption: false, alias: "o" },
   "account-priv-key": { type: "string", demandOption: false, alias: "account" },
+  "account-type": { type: "string", demandOption: false, alias: "accType", default: "ethereum" },
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
   "send-proposal-as": {
@@ -28,8 +29,8 @@ const args = yargs.options({
     alias: "s",
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
-  "delay": { type: "string", demandOption: false },
-  "track": { type: "string", demandOption: false }
+  delay: { type: "string", demandOption: false },
+  track: { type: "string", demandOption: false },
 }).argv;
 
 // Construct
@@ -71,7 +72,7 @@ async function main() {
   let account;
   let nonce;
   if (args["account-priv-key"]) {
-    [account, nonce] = await accountWrapper(api, args["account-priv-key"]);
+    [account, nonce] = await accountWrapper(api, args["account-priv-key"], args["account-type"]);
   }
 
   // Sudo Wrapper


### PR DESCRIPTION
XCM-Tools now support `ethereum`, `sr25519` and `ed25519` account derivation schemes when you are providing the private key to submit things like referenda etc.

`ethereum` is default. This was tested with Chopsticks and Polkadot.