### PR TITLE
Adds Decimals and Coefficient to Relative Price

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,30 +376,30 @@ yarn calculate-multilocation-derivative-account \
 
 ## Calculate Relative Price
 
-This script calculates how many units of your specified asset are equivalent to one native token on the given network (either GLMR or MOVR). The native token price is dynamically fetched from the CoinGecko API, while **your asset's price is provided directly as a command-line input**—no CoinGecko listing required for the asset.
+This script calculates how many units of your specified asset are equivalent to one native token on the given network (either GLMR or MOVR). The native token price is dynamically fetched from the CoinGecko API, while **your asset's USD price and decimals are provided as command-line inputs**—no CoinGecko listing required for the asset.
 
 ### Inputs
 
-* **Price (USD):** The USD price of your asset, provided as a command-line argument. Must be a positive number.
+* **Price (USD):** The USD price of your asset. Must be a positive number.
+* **Decimals:** The number of decimal places your asset uses. For example, if your token has 12 decimal places, use `12`.
 * **Network:** The target network's native token to compare against. Valid options are `GLMR` (Moonbeam) or `MOVR` (Moonriver).
 
 ### How It Works
 
 1. The script queries CoinGecko for the current USD price of the native token (`GLMR` or `MOVR`).
-2. It uses your supplied asset's USD price to determine how many units of your asset make up one native token.
-3. The result is scaled to 18 decimal places (the WEI-like format), making it compatible with scenarios that require precise integer-based values.
+2. It uses your supplied asset's USD price and decimal places to determine how many units of your asset make up one native token.
+3. The result is scaled appropriately based on your asset's decimals and the native token's 18 decimals (WEI format).
 
 ### Example Usage
 
 ```bash
-npx ts-node calculate-relative-price.ts 0.25 GLMR
+npx ts-node calculate-relative-price.ts 0.25 12 GLMR
 ```
 
-**Process:**
-* Your asset's USD price: `$0.25`
-* GLMR's fetched USD price: `$0.182707` (example)
-* Ratio calculation: 1 GLMR ≈ 0.731 of your asset
-* 18-decimal scaling: `1368311011619697152` units of your asset = `1 GLMR`
+This command uses:
+* Asset USD price: `$0.25`
+* Asset decimals: `12`
+* Network: `GLMR`
 
 ### Example Output
 
@@ -409,15 +409,32 @@ Calculating relative price for asset worth $0.25 against GLMR...
 Results:
 Asset Price: $0.25
 Network: GLMR
-Native Token Price (from CoinGecko): $0.182707
+Native Token Price (from CoinGecko): $0.158851
 
 Relative Price Analysis:
-1 GLMR is equal to approximately 0.731 of your specified token.
-With 18 decimals, 1 GLMR or in WEI, 1000000000000000000 is equal to a relative price of 1368311011619697152 units of your token
+1 GLMR is equal to approximately 0.635 of your specified token.
+With 18 decimals, 1 GLMR or in WEI, 1000000000000000000 is equal to a relative price of 275415326312078635958272 units of your token
 
-Relative Price: 1368311011619697152
+Relative Price: 275415326312078635958272
+The relative price you should specify in asset registration steps is 275415326312078635958272
+```
 
-The relative price you should specify in asset registration steps is 1368311011619697152
+### Command Format
+
+```bash
+npx ts-node calculate-relative-price.ts <price> <decimals> <network>
+```
+
+Where:
+* `<price>`: Your asset's price in USD (e.g., 0.25)
+* `<decimals>`: Number of decimal places your asset uses (e.g., 12)
+* `<network>`: Either GLMR or MOVR
+
+### Help Command
+
+For quick reference, you can use:
+```bash
+npx ts-node calculate-relative-price.ts --help
 ```
 
 ## Para-registrar-swap

--- a/scripts/calculate-relative-price.ts
+++ b/scripts/calculate-relative-price.ts
@@ -8,8 +8,9 @@ const NETWORK_IDS = {
 
 async function calculateRelativePrice(
   assetPrice: number,
+  assetDecimals: number,
   network: "GLMR" | "MOVR"
-): Promise<string> {
+): Promise<bigint> {
   try {
     // Fetch the native token price from CoinGecko
     const response = await axios.get(
@@ -21,10 +22,12 @@ async function calculateRelativePrice(
     // Calculate relative price with 18 decimal places
     // Formula: (assetPrice / nativeTokenPrice) * 10^18
     // This gives us how many units of the asset we need to equal 1 unit of native token
-    const relativePrice = ( assetPrice / nativeTokenPrice ) * Math.pow(10, 18);
+    const relativePrice = BigInt(
+      0.175 * Math.pow(10, 18 - assetDecimals) * (assetPrice / nativeTokenPrice) * Math.pow(10, 18)
+    );
 
     // Return as string to preserve precision
-    return relativePrice.toFixed(0);
+    return relativePrice;
   } catch (error) {
     if (error instanceof Error) {
       throw new Error(`Failed to calculate relative price: ${error.message}`);
@@ -35,12 +38,19 @@ async function calculateRelativePrice(
 
 function validateInput(
   price: string,
+  decimals: string,
   network: string
-): { assetPrice: number; network: "GLMR" | "MOVR" } {
+): { assetPrice: number; assetDecimals: number; network: "GLMR" | "MOVR" } {
   // Validate price
   const assetPrice = parseFloat(price);
   if (isNaN(assetPrice) || assetPrice <= 0) {
     throw new Error("Price must be a positive number");
+  }
+
+  // Validate decimals
+  const assetDecimals = parseFloat(decimals);
+  if (isNaN(assetDecimals) || assetDecimals <= 0) {
+    throw new Error("Decimals must be a positive number");
   }
 
   // Validate network
@@ -49,23 +59,24 @@ function validateInput(
     throw new Error("Network must be either GLMR or MOVR");
   }
 
-  return { assetPrice, network: upperNetwork };
+  return { assetPrice, assetDecimals, network: upperNetwork };
 }
 
 function printUsage() {
   console.log("\nUsage:");
-  console.log("npx ts-node relative-price-calculator.ts <price> <network>");
+  console.log("npx ts-node relative-price-calculator.ts <price> <decimals> <network>");
   console.log("\nExample:");
-  console.log("npx ts-node relative-price-calculator.ts 0.25 GLMR");
+  console.log("npx ts-node relative-price-calculator.ts 0.25 12 GLMR");
   console.log("\nParameters:");
-  console.log("price   - The price of your asset in USD");
-  console.log("network - Either GLMR or MOVR");
+  console.log("price      - The price of your asset in USD");
+  console.log("decimals   - The decimals of your asset");
+  console.log("network    - Either GLMR or MOVR");
 }
 
 async function main() {
   try {
     // Get command line arguments
-    const [, , price, network] = process.argv;
+    const [, , price, decimals, network] = process.argv;
 
     // Check if help flag is passed
     if (price === "--help" || price === "-h") {
@@ -74,19 +85,23 @@ async function main() {
     }
 
     // Check if required arguments are provided
-    if (!price || !network) {
+    if (!price || !decimals || !network) {
       console.error("Error: Missing required arguments");
       printUsage();
       process.exit(1);
     }
 
     // Validate inputs
-    const { assetPrice, network: validNetwork } = validateInput(price, network);
+    const {
+      assetPrice,
+      assetDecimals,
+      network: validNetwork,
+    } = validateInput(price, decimals, network);
 
     console.log(
       `\nCalculating relative price for asset worth $${assetPrice} against ${validNetwork}...`
     );
-    const relativePrice = await calculateRelativePrice(assetPrice, validNetwork);
+    const relativePrice = await calculateRelativePrice(assetPrice, assetDecimals, validNetwork);
     const nativeTokenPrice = (
       await axios.get(
         `https://api.coingecko.com/api/v3/simple/price?ids=${NETWORK_IDS[validNetwork]}&vs_currencies=usd`

--- a/scripts/calculate-relative-price.ts
+++ b/scripts/calculate-relative-price.ts
@@ -64,9 +64,9 @@ function validateInput(
 
 function printUsage() {
   console.log("\nUsage:");
-  console.log("npx ts-node relative-price-calculator.ts <price> <decimals> <network>");
+  console.log("npx ts-node calculate-relative-price.ts <price> <decimals> <network>");
   console.log("\nExample:");
-  console.log("npx ts-node relative-price-calculator.ts 0.25 12 GLMR");
+  console.log("npx ts-node calculate-relative-price.ts 0.25 12 GLMR");
   console.log("\nParameters:");
   console.log("price      - The price of your asset in USD");
   console.log("decimals   - The decimals of your asset");


### PR DESCRIPTION
This modifies the relative price script to add a coefficient (for Moonbeam) and also consider decimals. 

For a stable coin with 12 decimals we were charming 4k EUR which was insane.